### PR TITLE
This fixes the System.ComponentModel.Annotations not found.

### DIFF
--- a/DerethForever.Web/DerethForever.Web.csproj
+++ b/DerethForever.Web/DerethForever.Web.csproj
@@ -62,6 +62,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel" />
+    <Reference Include="System.ComponentModel.Annotations, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ComponentModel.Annotations.4.4.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
+    </Reference>
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/DerethForever.Web/packages.config
+++ b/DerethForever.Web/packages.config
@@ -28,6 +28,7 @@
   <package id="selectize" version="0.12.1" targetFramework="net452" />
   <package id="SharpZipLib" version="1.0.0" targetFramework="net452" />
   <package id="StyleCop.MSBuild" version="5.0.0" targetFramework="net452" developmentDependency="true" />
+  <package id="System.ComponentModel.Annotations" version="4.4.0" targetFramework="net462" />
   <package id="System.Net.Http" version="4.3.3" targetFramework="net462" />
   <package id="System.Net.Primitives" version="4.3.0" targetFramework="net452" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net462" />

--- a/Lifestoned.DataModel/Lifestoned.DataModel.csproj
+++ b/Lifestoned.DataModel/Lifestoned.DataModel.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
References:
https://stackoverflow.com/questions/50342416/azure-function-ef-core-cant-load-componentmodel-annotations-4-2-0-0/50776946#50776946

https://stackoverflow.com/questions/44053187/could-not-load-file-or-assembly-system-componentmodel-annotations-version-4-1

The nuget package has been added to DerethForever.Web (even though it's only needed by Lifestoned.DataModel) to force the project obtain it.

Also, the latest version of the package, 4.5.0 will still fail. Currently the 4.4.0 package is required.